### PR TITLE
ci(build): create uv venv before verifying wheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,8 +228,9 @@ jobs:
 
       - name: Verify package
         run: |
+          uv venv
           uv pip install dist/*.whl
-          python -c "import domainraptor; print(f'Package version: {domainraptor.__version__}')"
+          uv run python -c "import domainraptor; print(f'Package version: {domainraptor.__version__}')"
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
uv pip install requires a virtual environment (or --system). Create one explicitly with 'uv venv' and run the import smoke-test via 'uv run' so the installed wheel is resolvable.