### PR TITLE
fix(tui,discovery): export CertSpotterClient, improve compare arg2 UX

### DIFF
--- a/src/domainraptor/discovery/__init__.py
+++ b/src/domainraptor/discovery/__init__.py
@@ -10,6 +10,7 @@ from domainraptor.discovery.censys_client import (
     CensysClient,
     CensysHostResult,
 )
+from domainraptor.discovery.certspotter import CertSpotterClient
 from domainraptor.discovery.crtsh import CrtShClient
 from domainraptor.discovery.dns import DnsClient, DnsConfig
 from domainraptor.discovery.hackertarget import HackerTargetClient
@@ -27,6 +28,7 @@ __all__ = [
     "CensysCertificateResult",
     "CensysClient",
     "CensysHostResult",
+    "CertSpotterClient",
     "ClientConfig",
     "CrtShClient",
     "DiscoveryOrchestrator",

--- a/src/domainraptor/tui/screens/compare.py
+++ b/src/domainraptor/tui/screens/compare.py
@@ -35,7 +35,7 @@ class CompareScreen(Widget):
                 yield Label("Target:", id="arg1-label")
                 yield Input(placeholder="example.com", id="arg1")
             with Horizontal(classes="arg-row", id="row-arg2"):
-                yield Label("Arg 2:")
+                yield Label("Arg 2:", id="arg2-label")
                 yield Input(placeholder="(optional) scan-id or target", id="arg2")
             # Run button is provided by ScanRunner; no separate one here.
             yield ScanRunner(id="runner")
@@ -50,12 +50,24 @@ class CompareScreen(Widget):
     def _apply_subcmd_visibility(self, sub: str) -> None:
         # All subcommands need a target/scan-id, so 'arg1' is always visible.
         # 'history' takes exactly one positional (target) — hide arg2.
-        # 'scans' takes two scan-ids; 'targets' takes two targets — show arg2.
+        # 'scans' takes two scan-ids; 'targets' takes two targets — show arg2
+        # and label/placeholder it accordingly (it is REQUIRED for those two,
+        # not optional, so do not advertise it as such).
         arg1_label = "Target:" if sub in {"history", "targets"} else "Scan-id:"
         arg1_placeholder = "example.com" if sub in {"history", "targets"} else "scan-id (e.g. 42)"
         with contextlib.suppress(Exception):
             self.query_one("#arg1-label", Label).update(arg1_label)
             self.query_one("#arg1", Input).placeholder = arg1_placeholder
+
+        if sub == "targets":
+            arg2_label, arg2_placeholder = "Target B:", "other.example.com"
+        elif sub == "scans":
+            arg2_label, arg2_placeholder = "Scan B:", "scan-id (e.g. 43)"
+        else:  # history
+            arg2_label, arg2_placeholder = "Arg 2:", "(unused for history)"
+        with contextlib.suppress(Exception):
+            self.query_one("#arg2-label", Label).update(arg2_label)
+            self.query_one("#arg2", Input).placeholder = arg2_placeholder
         with contextlib.suppress(Exception):
             self.query_one("#row-arg2").display = sub != "history"
 
@@ -72,6 +84,10 @@ class CompareScreen(Widget):
         if not a:
             label = "target" if sub in {"history", "targets"} else "scan-id"
             runner.append(f"[yellow]Please provide a {label} in Arg 1.[/yellow]")
+            return
+        if sub in {"scans", "targets"} and not b:
+            label = "second target" if sub == "targets" else "second scan-id"
+            runner.append(f"[yellow]Please provide a {label} in Arg 2.[/yellow]")
             return
         args = ["compare", sub, a]
         if b and sub != "history":

--- a/src/domainraptor/tui/screens/compare.py
+++ b/src/domainraptor/tui/screens/compare.py
@@ -16,7 +16,10 @@ class CompareScreen(Widget):
     DEFAULT_CSS = """
     CompareScreen { height: 1fr; }
     CompareScreen .arg-row { height: auto; }
-    CompareScreen .arg-row Label { padding: 1 1 0 0; width: 8; }
+    /* Width 12 fits the longest dynamic label ("Target B:" is 9 chars and
+       "Scan-id:" is 8) with a little padding so nothing wraps when the
+       subcommand changes. */
+    CompareScreen .arg-row Label { padding: 1 1 0 0; width: 12; }
     CompareScreen .arg-row Input { width: 1fr; }
     """
 
@@ -81,13 +84,16 @@ class CompareScreen(Widget):
         sub = str(self.query_one("#subcmd", Select).value)
         a = self.query_one("#arg1", Input).value.strip()
         b = self.query_one("#arg2", Input).value.strip()
+        # Mirror the dynamic field labels in the validation messages so the
+        # wording stays consistent with what the user actually sees on screen
+        # (e.g. "Target B" rather than the generic "Arg 2").
+        arg1_field = "Target" if sub in {"history", "targets"} else "Scan-id"
         if not a:
-            label = "target" if sub in {"history", "targets"} else "scan-id"
-            runner.append(f"[yellow]Please provide a {label} in Arg 1.[/yellow]")
+            runner.append(f"[yellow]Please provide a value for {arg1_field}.[/yellow]")
             return
         if sub in {"scans", "targets"} and not b:
-            label = "second target" if sub == "targets" else "second scan-id"
-            runner.append(f"[yellow]Please provide a {label} in Arg 2.[/yellow]")
+            arg2_field = "Target B" if sub == "targets" else "Scan B"
+            runner.append(f"[yellow]Please provide a value for {arg2_field}.[/yellow]")
             return
         args = ["compare", sub, a]
         if b and sub != "history":


### PR DESCRIPTION
Address PR #61 review feedback:

- discovery/__init__: export CertSpotterClient alongside CrtShClient and the other sibling clients so 'from domainraptor.discovery import CertSpotterClient' works (matches the established convention).
- tui/compare: arg2 was always labelled 'Arg 2:' with the placeholder '(optional) scan-id or target', even for 'compare scans' / 'compare targets' where the second argument is REQUIRED by the CLI. Relabel and re-placeholder arg2 alongside arg1 when the subcommand changes (Target B / Scan B / unused-for-history), and reject submissions that leave arg2 blank for scans/targets with a friendly inline message mirroring the existing arg1 validation.